### PR TITLE
Passes editor_selector specified in configuration to jquery versions of ...

### DIFF
--- a/lib/tiny_mce/helpers.rb
+++ b/lib/tiny_mce/helpers.rb
@@ -20,8 +20,7 @@ module TinyMCE
         configuration.add_options(options, raw_options)
         
         if uses_jquery?
-          #TODO: Use dynamic editor_selector from configuration
-          tinymce_js += "$(function(){ $('textarea.mceEditor').tinymce("
+          tinymce_js += "$(function(){ $('textarea.#{configuration.options['editor_selector']}').tinymce("
           tinymce_js += configuration.to_json
           tinymce_js += ");"
           tinymce_js += "});"


### PR DESCRIPTION
...tiny_mce.

The uses_jquery? method should probably be configuration controlled rather than automatic. We ran into an issue where, using jammit, the production version would use normal tinymce javascript and the development version would use the jquery version. 

The main issue was that editor_selector wasn't getting passed through to the jquery selector -- so this will fix it. 
